### PR TITLE
Refresh usage info with live env example and agnostic guidance

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -110,8 +110,8 @@ pre {
 
 .button-group {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 14px;
+  right: 14px;
   display: flex;
   gap: 8px;
 }

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -159,22 +159,13 @@ pre {
   padding-bottom: 8px;
 }
 
-.live-env-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 16px;
+.icon-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
-.live-env-header h2 {
-  margin: 0;
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.live-env-example {
-  border: 1px solid var(--bg-tertiary);
+.icon-btn:disabled:hover {
+  background-color: rgba(39, 39, 42, 0.7);
 }
 
 .usage-list {
@@ -202,28 +193,10 @@ pre {
   color: var(--accent-hover);
 }
 
-.copy-env-btn {
-  background-color: var(--bg-tertiary);
-  color: var(--text-primary);
-  border: 1px solid var(--bg-tertiary);
-  padding: 6px 12px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  border-radius: 4px;
-  transition: var(--transition);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.copy-env-btn:hover:not(:disabled) {
-  background-color: var(--text-secondary);
-  color: var(--bg-primary);
-}
-
-.copy-env-btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+.usage-info .secret-display pre {
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
 }
 
 .usage-info p {

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -154,15 +154,76 @@ pre {
 .usage-info h2 {
   color: var(--text-primary);
   margin: 0 0 16px 0;
-  font-size: 24px;
+  font-size: 20px;
   border-bottom: 1px solid var(--bg-tertiary);
   padding-bottom: 8px;
 }
 
-.usage-info h3 {
+.live-env-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.live-env-header h2 {
+  margin: 0;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.live-env-example {
+  border: 1px solid var(--bg-tertiary);
+}
+
+.usage-list {
+  color: var(--text-secondary);
+  margin: 12px 0;
+  padding-left: 20px;
+  font-size: 15px;
+}
+
+.usage-list li {
+  margin-bottom: 10px;
+}
+
+.usage-list li:last-child {
+  margin-bottom: 0;
+}
+
+.usage-info a {
   color: var(--text-primary);
-  margin: 20px 0 12px 0;
-  font-size: 18px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.usage-info a:hover {
+  color: var(--accent-hover);
+}
+
+.copy-env-btn {
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--bg-tertiary);
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: var(--transition);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.copy-env-btn:hover:not(:disabled) {
+  background-color: var(--text-secondary);
+  color: var(--bg-primary);
+}
+
+.copy-env-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .usage-info p {
@@ -216,15 +277,6 @@ pre {
   font-size: 12px;
   font-family: 'Menlo', 'Monaco', 'Consolas', monospace;
   margin-left: 6px;
-}
-
-/* Platform section spacing */
-.platform-section {
-  margin-bottom: 24px;
-}
-
-.platform-section:last-child {
-  margin-bottom: 0;
 }
 
 /* Copy indicator */

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -5,7 +5,11 @@ document.addEventListener("DOMContentLoaded", () => {
     showUsage: false,
   };
 
+  const PLACEHOLDER_ENV_LINE = 'PAYLOAD_SECRET="generate a secret above"';
+
   window.getSecret = () => state.secret;
+  window.getEnvLine = () =>
+    state.secret ? `PAYLOAD_SECRET="${state.secret}"` : "";
 
   const elements = {
     generateBtn: document.getElementById("generateBtn"),
@@ -14,10 +18,11 @@ document.addEventListener("DOMContentLoaded", () => {
     secretField: document.getElementById("secretField"),
     toggleVisibilityBtn: document.getElementById("toggleVisibilityBtn"),
     usageInfo: document.getElementById("usageInfo"),
+    liveEnvExample: document.getElementById("liveEnvExample"),
+    copyEnvBtn: document.getElementById("copyEnvBtn"),
     eyeIcon: document.getElementById("eyeIcon"),
   };
 
-  // Track page engagement time
   let startTime = Date.now();
   window.addEventListener("beforeunload", () => {
     const timeSpent = Math.round((Date.now() - startTime) / 1000);
@@ -28,25 +33,47 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
+  function getDisplayedSecret() {
+    if (!state.secret) return "";
+    return state.showSecret
+      ? state.secret
+      : state.secret.slice(0, 8) + "•".repeat(state.secret.length - 8);
+  }
+
+  function updateSecretDisplay() {
+    elements.secretField.textContent = getDisplayedSecret();
+    updateLiveEnvExample();
+  }
+
+  function updateLiveEnvExample() {
+    if (!state.secret) {
+      elements.liveEnvExample.textContent = PLACEHOLDER_ENV_LINE;
+      elements.copyEnvBtn.disabled = true;
+      return;
+    }
+
+    elements.liveEnvExample.textContent = `PAYLOAD_SECRET="${getDisplayedSecret()}"`;
+    elements.copyEnvBtn.disabled = false;
+  }
+
+  function showUsageInfo() {
+    if (state.showUsage) return;
+    state.showUsage = true;
+    elements.usageInfo.classList.remove("hidden");
+  }
+
   function generateSecret() {
     const array = new Uint8Array(32);
     crypto.getRandomValues(array);
     state.secret = btoa(String.fromCharCode(...array));
     updateSecretDisplay();
     elements.secretContainer.classList.remove("hidden");
+    showUsageInfo();
 
-    // Track secret generation
     gtag("event", "generate_secret", {
       event_category: "Interaction",
       event_label: "Generate Secret",
     });
-  }
-
-  function updateSecretDisplay() {
-    const displayedSecret = state.showSecret
-      ? state.secret
-      : state.secret.slice(0, 8) + "•".repeat(state.secret.length - 8);
-    elements.secretField.textContent = displayedSecret;
   }
 
   function toggleSecretVisibility() {
@@ -54,7 +81,6 @@ document.addEventListener("DOMContentLoaded", () => {
     updateSecretDisplay();
     elements.eyeIcon.textContent = state.showSecret ? "🙈" : "🙉";
 
-    // Track secret visibility toggle
     gtag("event", "toggle_visibility", {
       event_category: "Interaction",
       event_label: state.showSecret ? "Show Secret" : "Hide Secret",
@@ -65,7 +91,6 @@ document.addEventListener("DOMContentLoaded", () => {
     state.showUsage = !state.showUsage;
     elements.usageInfo.classList.toggle("hidden");
 
-    // Track usage info toggle
     gtag("event", "toggle_usage", {
       event_category: "Interaction",
       event_label: state.showUsage ? "Show Usage" : "Hide Usage",

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -56,19 +56,12 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.copyEnvBtn.disabled = false;
   }
 
-  function showUsageInfo() {
-    if (state.showUsage) return;
-    state.showUsage = true;
-    elements.usageInfo.classList.remove("hidden");
-  }
-
   function generateSecret() {
     const array = new Uint8Array(32);
     crypto.getRandomValues(array);
     state.secret = btoa(String.fromCharCode(...array));
     updateSecretDisplay();
     elements.secretContainer.classList.remove("hidden");
-    showUsageInfo();
 
     gtag("event", "generate_secret", {
       event_category: "Interaction",

--- a/public/assets/js/copyButton.js
+++ b/public/assets/js/copyButton.js
@@ -33,17 +33,9 @@ class CopyButton {
   }
 
   showCopiedFeedback() {
-    if (this.icon) {
-      this.icon.textContent = "✓";
-      setTimeout(() => {
-        this.icon.textContent = this.initialLabel;
-      }, 2000);
-      return;
-    }
-
-    this.button.textContent = "Copied";
+    this.icon.textContent = "✓";
     setTimeout(() => {
-      this.button.textContent = this.initialLabel;
+      this.icon.textContent = this.initialLabel;
     }, 2000);
   }
 

--- a/public/assets/js/copyButton.js
+++ b/public/assets/js/copyButton.js
@@ -1,28 +1,30 @@
 class CopyButton {
-  constructor(buttonElement) {
+  constructor(buttonElement, getValue, eventLabel) {
     this.button = buttonElement;
-    this.copyIcon = this.button.querySelector(".icon");
-    this.initialIcon = this.copyIcon.textContent;
+    this.getValue = getValue;
+    this.eventLabel = eventLabel;
+    this.icon = this.button.querySelector(".icon");
+    this.initialLabel = this.icon
+      ? this.icon.textContent
+      : this.button.textContent;
     this.setupEventListeners();
   }
 
   async copyToClipboard() {
     try {
-      const value = window.getSecret();
+      const value = this.getValue();
       if (!value) return;
 
       await navigator.clipboard.writeText(value);
       this.showCopiedFeedback();
 
-      // Track successful copy
       gtag("event", "copy_secret", {
         event_category: "Interaction",
-        event_label: "Copy Secret",
+        event_label: this.eventLabel,
       });
     } catch (err) {
       console.error("Failed to copy text: ", err);
 
-      // Track copy failure
       gtag("event", "copy_error", {
         event_category: "Error",
         event_label: err.message,
@@ -31,9 +33,17 @@ class CopyButton {
   }
 
   showCopiedFeedback() {
-    this.copyIcon.textContent = "✓";
+    if (this.icon) {
+      this.icon.textContent = "✓";
+      setTimeout(() => {
+        this.icon.textContent = this.initialLabel;
+      }, 2000);
+      return;
+    }
+
+    this.button.textContent = "Copied";
     setTimeout(() => {
-      this.copyIcon.textContent = this.initialIcon;
+      this.button.textContent = this.initialLabel;
     }, 2000);
   }
 
@@ -44,5 +54,8 @@ class CopyButton {
 
 document.addEventListener("DOMContentLoaded", () => {
   const copyBtn = document.getElementById("copyBtn");
-  new CopyButton(copyBtn);
+  new CopyButton(copyBtn, () => window.getSecret(), "Copy Secret");
+
+  const copyEnvBtn = document.getElementById("copyEnvBtn");
+  new CopyButton(copyEnvBtn, () => window.getEnvLine(), "Copy Env Line");
 });

--- a/public/index.html
+++ b/public/index.html
@@ -64,12 +64,16 @@
         </div>
 
         <div class="usage-section">
-          <div class="live-env-header">
-            <h2>Environment variable</h2>
-            <button id="copyEnvBtn" class="copy-env-btn" disabled>Copy line</button>
-          </div>
+          <h2>Environment variable</h2>
           <p>Add this line to your environment:</p>
-          <pre id="liveEnvExample" class="live-env-example">PAYLOAD_SECRET="generate a secret above"</pre>
+          <div class="secret-display">
+            <pre id="liveEnvExample">PAYLOAD_SECRET="generate a secret above"</pre>
+            <div class="button-group">
+              <button id="copyEnvBtn" class="icon-btn" disabled aria-label="Copy line">
+                <span class="icon">📋</span>
+              </button>
+            </div>
+          </div>
         </div>
 
         <div class="usage-section">

--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
 
       <div class="controls">
         <button id="generateBtn" class="btn">Generate</button>
-        <button id="usageBtn" class="btn">Usage</button>
+        <button id="usageBtn" class="btn">How to use</button>
       </div>
 
       <div id="secretContainer" class="secret-container hidden">
@@ -54,76 +54,69 @@
 
       <div id="usageInfo" class="usage-info hidden">
         <div class="usage-section">
-          <h2>Development</h2>
-          <p>Add the secret to your <code>.env</code> file:</p>
-          <pre>PAYLOAD_SECRET="your_generated_secret_here"</pre>
-
-          <p>For local development with Docker, add it to your <code>docker-compose.yml</code> environment variables:
+          <h2>What is <code>PAYLOAD_SECRET</code>?</h2>
+          <p>
+            <code>PAYLOAD_SECRET</code> is a required environment variable for Payload. It is a long,
+            random, unguessable string that Payload uses for encryption workflows — signing and
+            verifying auth tokens, password hashing, and other server-side crypto. It is not an API
+            key you paste into the admin UI; your app reads it from the environment at startup.
           </p>
-          <pre>
-      environment:
-        PAYLOAD_SECRET: "your_generated_secret_here"</pre>
         </div>
 
         <div class="usage-section">
-          <h2>Production</h2>
-          <p>Set the secret in your hosting platform:</p>
-
-          <div class="platform-section">
-            <h3>Vercel</h3>
-            <pre>
-      # Using Vercel CLI
-      vercel env add PAYLOAD_SECRET your_generated_secret_here
-      
-      # Or add via Vercel dashboard:
-      # Project Settings > Environment Variables > Add New</pre>
+          <div class="live-env-header">
+            <h2>Environment variable</h2>
+            <button id="copyEnvBtn" class="copy-env-btn" disabled>Copy line</button>
           </div>
-
-          <div class="platform-section">
-            <h3>Railway</h3>
-            <pre>
-      # Add via Railway dashboard:
-      # Project Settings > Variables > New Variable
-      PAYLOAD_SECRET=your_generated_secret_here</pre>
-          </div>
-
-          <div class="platform-section">
-            <h3>Netlify</h3>
-            <pre>
-      # Using Netlify CLI
-      netlify env:set PAYLOAD_SECRET your_generated_secret_here
-      
-      # Or add via Netlify dashboard:
-      # Site settings > Environment variables > Add variable</pre>
-          </div>
+          <p>Add this line to your environment:</p>
+          <pre id="liveEnvExample" class="live-env-example">PAYLOAD_SECRET="generate a secret above"</pre>
         </div>
 
         <div class="usage-section">
-          <h2>Code</h2>
-          <p>In your Payload config:</p>
-          <pre>
-      import { buildConfig } from 'payload/config';
-      
-      export default buildConfig({
-        secret: process.env.PAYLOAD_SECRET,
-        // ... rest of your config
-      });</pre>
+          <h2>Where to set it</h2>
+          <ul class="usage-list">
+            <li>
+              <strong>Local development:</strong> add the line to a <code>.env</code> file at your
+              project root and keep <code>.env</code> out of version control.
+            </li>
+            <li>
+              <strong>Deployed environments:</strong> set <code>PAYLOAD_SECRET</code> in your host's
+              environment-variable settings — same variable name, available to the Node process before
+              Payload starts.
+            </li>
+            <li>
+              <strong>Containers:</strong> pass <code>PAYLOAD_SECRET</code> as an environment variable
+              to your app service.
+            </li>
+          </ul>
+        </div>
 
-          <p>For TypeScript projects:</p>
-          <pre>
-      import { buildConfig } from 'payload/config';
-      import { Config } from 'payload/types';
-      
-      const config: Config = buildConfig({
-        secret: process.env.PAYLOAD_SECRET,
-        // ... rest of your config
-      });
-      
-      export default config;</pre>
+        <div class="usage-section">
+          <h2>In your Payload config</h2>
+          <p>Reference the variable in <code>payload.config.ts</code>:</p>
+          <pre>import { buildConfig } from 'payload'
+
+export default buildConfig({
+  secret: process.env.PAYLOAD_SECRET,
+  // ...
+})</pre>
+          <p>
+            Payload reads <code>process.env.PAYLOAD_SECRET</code> when your config loads. If the
+            variable is missing, Payload will fail at startup.
+            <a href="https://payloadcms.com/docs/configuration/environment-vars" target="_blank" rel="noopener noreferrer">Read more in the Payload docs</a>.
+          </p>
+        </div>
+
+        <div class="usage-section">
+          <h2>Good to know</h2>
+          <ul class="usage-list">
+            <li>Never commit secrets to git or expose them in client-side code (avoid the <code>NEXT_PUBLIC_</code> prefix).</li>
+            <li>Use a unique secret for each environment — local, staging, and production.</li>
+            <li>If a secret is leaked, rotate it; existing sessions and tokens may be invalidated.</li>
+            <li>This generator produces a 32-byte random value encoded as base64, which meets Payload's requirement for a long, unguessable secret.</li>
+          </ul>
         </div>
       </div>
-
-
 
       <div class="footer">
         <a href="https://github.com/eminent-sh/payloadsecret.com" target="_blank" rel="noopener noreferrer">♥ eminent.sh</a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refreshes the usage information panel below the secret generator with hosting-agnostic guidance and a live environment variable example.

- Introduces `PAYLOAD_SECRET` as a required environment variable with a short explanation of what Payload uses it for
- Adds a live `.env` line (`PAYLOAD_SECRET="..."`) that updates when a secret is generated and follows the same show/hide masking as the field above
- Reuses existing `secret-display`, `button-group`, and `icon-btn` patterns for the env-line copy control (clipboard icon + checkmark feedback)
- Replaces platform-specific deployment instructions (Vercel, Railway, Netlify) with generic guidance for local `.env`, deployed hosts, and containers
- Updates the Payload config example to current `import { buildConfig } from 'payload'` syntax
- **How to use** toggles the usage panel only — Generate no longer opens it automatically

## Test plan

- [x] Generate a secret — usage panel stays hidden unless opened via How to use
- [x] Live env example shows masked value matching the secret field
- [x] Eye toggle reveals/hides both fields in sync
- [x] Env copy icon matches secret copy icon styling and shows checkmark feedback
- [x] How to use collapses and re-expands the panel
- [x] No Vercel, Railway, or Netlify references remain
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00d55b86-f6e1-4bde-9623-c38289c82a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00d55b86-f6e1-4bde-9623-c38289c82a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

