### PR TITLE
Track hits on /generate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,4 +18,9 @@ Then open `http://localhost:8080/` in a browser.
 
 - There is no linter, test framework, or build step configured in this repo.
 - The app uses browser-native `crypto.getRandomValues()` — no Node.js or npm required.
-- Google Analytics (`gtag.js`) is loaded from an external CDN; it works automatically over HTTP(S) and does not need local configuration.
+- Google Analytics (`gtag.js`) is loaded from an external CDN on the homepage; it works automatically over HTTP(S) and does not need local configuration.
+- `/generate` API hits are tracked server-side via GA4 Measurement Protocol in [`public/_worker.js`](public/_worker.js). This requires a Cloudflare Pages environment variable:
+
+  1. In GA4: **Admin → Data streams → (web stream) → Measurement Protocol API secrets → Create**
+  2. In Cloudflare Pages: set `GA_API_SECRET` to that secret (production). Optionally set `GA_MEASUREMENT_ID` (defaults to `G-8KTZ04YFHP`).
+  3. Deploy. Verify with `curl -fsSL https://payloadsecret.com/generate` and check GA4 **Realtime** for the `api_generate` event.

--- a/public/_worker.js
+++ b/public/_worker.js
@@ -1,3 +1,5 @@
+const DEFAULT_GA_MEASUREMENT_ID = "G-8KTZ04YFHP";
+
 function generateSecret() {
   const bytes = crypto.getRandomValues(new Uint8Array(32));
   let binary = "";
@@ -7,12 +9,69 @@ function generateSecret() {
   return btoa(binary);
 }
 
+function truncate(value, maxLength) {
+  if (!value) return undefined;
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+async function trackApiGenerate(request, env) {
+  const measurementId = env.GA_MEASUREMENT_ID || DEFAULT_GA_MEASUREMENT_ID;
+  const apiSecret = env.GA_API_SECRET;
+
+  if (!apiSecret) return;
+
+  const url = new URL(request.url);
+  const referer = request.headers.get("Referer");
+  const userAgent = request.headers.get("User-Agent");
+  const country = request.cf?.country;
+
+  const payload = {
+    client_id: crypto.randomUUID(),
+    events: [
+      {
+        name: "api_generate",
+        params: {
+          engagement_time_msec: 1,
+          page_location: url.href,
+          page_path: url.pathname,
+          method: request.method,
+          ...(referer ? { referer: truncate(referer, 500) } : {}),
+          ...(userAgent ? { user_agent: truncate(userAgent, 500) } : {}),
+          ...(country ? { country } : {}),
+        },
+      },
+    ],
+  };
+
+  const endpoint = new URL("https://www.google-analytics.com/mp/collect");
+  endpoint.searchParams.set("measurement_id", measurementId);
+  endpoint.searchParams.set("api_secret", apiSecret);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.error("GA4 Measurement Protocol error:", response.status);
+    }
+  } catch (error) {
+    console.error("GA4 Measurement Protocol request failed:", error);
+  }
+}
+
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
     if (url.pathname === "/generate" && request.method === "GET") {
       const secret = generateSecret();
+
+      if (env.GA_API_SECRET) {
+        ctx.waitUntil(trackApiGenerate(request, env));
+      }
 
       return new Response(secret, {
         headers: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Analytics-only side effect on an existing public endpoint; failures are logged and do not block secret responses.
> 
> **Overview**
> Adds **server-side analytics** for `GET /generate` so API usage shows up in GA4 even when clients never load the homepage `gtag.js`.
> 
> The Cloudflare Pages worker now fires a GA4 Measurement Protocol `api_generate` event in the background (`ctx.waitUntil`) when `GA_API_SECRET` is set, sending path, method, and optional referer, user agent, and country. Secret generation and the plain-text response are unchanged; if the secret is missing, tracking is skipped with no effect on the endpoint.
> 
> **AGENTS.md** documents how to create the Measurement Protocol secret, set `GA_API_SECRET` (and optional `GA_MEASUREMENT_ID`) in Cloudflare Pages, and verify via Realtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef40a07ba9072bfdcbbc981cc2f97822d84d6098. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->